### PR TITLE
Improve button focus outline

### DIFF
--- a/es.array.filter.js
+++ b/es.array.filter.js
@@ -1,0 +1,15 @@
+'use strict';
+var $ = require('../internals/export');
+var $filter = require('../internals/array-iteration').filter;
+var arrayMethodHasSpeciesSupport = require('../internals/array-method-has-species-support');
+
+var HAS_SPECIES_SUPPORT = arrayMethodHasSpeciesSupport('filter');
+
+// `Array.prototype.filter` method
+// https://tc39.es/ecma262/#sec-array.prototype.filter
+// with adding support of @@species
+$({ target: 'Array', proto: true, forced: !HAS_SPECIES_SUPPORT }, {
+  filter: function filter(callbackfn /* , thisArg */) {
+    return $filter(this, callbackfn, arguments.length > 1 ? arguments[1] : undefined);
+  }
+});


### PR DESCRIPTION
Increase contrast and thickness of primary button focus outline to improve keyboard accessibility. This updates CSS to use :focus-visible with a darker outline color and 3px width, preventing noisy outlines on touch devices.